### PR TITLE
Add ErrorAction when checking DNS resource records

### DIFF
--- a/InfraDNS/Tests/Integration/DNSServer.tests.ps1
+++ b/InfraDNS/Tests/Integration/DNSServer.tests.ps1
@@ -73,7 +73,7 @@ Describe 'DNS Server' {
         }
 
         It "Should have a CName record for DNS pointing to TestAgent1" {
-            (Get-DnsServerResourceRecord -Name dns -ZoneName contoso.com).RecordData.HostNameAlias | Should match 'TestAgent1.'
+            (Get-DnsServerResourceRecord -Name dns -ZoneName contoso.com -ErrorAction SilentlyContinue).RecordData.HostNameAlias | Should match 'TestAgent1.'
         }
     }
 }


### PR DESCRIPTION
Without this, if a lookup was performed and the record was not present, an exception occurred and Pester would exit without writing the NUnit XML.