### PR TITLE
Adding dependency

### DIFF
--- a/InfraDNS/Deploy.ps1
+++ b/InfraDNS/Deploy.ps1
@@ -32,7 +32,7 @@ Properties {
     $MOFArtifactPath = "$ArtifactPath\MOF"
 }
 
-Task Default -depends AcceptanceTests
+Task Default -depends AcceptanceTests, IntegrationTests
 
 Task DeployModules -Depends Clean {
     # Copy resources from build agent to target node(s)


### PR DESCRIPTION
Making sure that the script returns a failure if Integration tests fail.  It is unclear whether this is required.